### PR TITLE
Bugfixes

### DIFF
--- a/chess-client/src/components/Game.js
+++ b/chess-client/src/components/Game.js
@@ -60,7 +60,7 @@ const Game = ({ selectedGame, emitState, emitLeave, emitEnd }) => {
   }
 
   const handleMove = (move) => {
-    if (selectedGame.player.id === null) {
+    if (selectedGame.player.id === null || selectedGame.host.id === null) {
       setErrorMessage('Wait for opponent or play as opponent from another window')
     }
     else if (isMyTurn() && game.move(move)) {

--- a/chess-client/src/components/Game.js
+++ b/chess-client/src/components/Game.js
@@ -60,7 +60,10 @@ const Game = ({ selectedGame, emitState, emitLeave, emitEnd }) => {
   }
 
   const handleMove = (move) => {
-    if (isMyTurn() && game.move(move)) {
+    if (selectedGame.player.id === null) {
+      setErrorMessage('Wait for opponent or play as opponent from another window')
+    }
+    else if (isMyTurn() && game.move(move)) {
       setPosition(game.fen())
       broadcastFen(game.fen())
       if (game.game_over()) {

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ const path = require('path')
 const app = express()
 const http = require('http').Server(app)
 const io = require('socket.io')(http, { cors: { origin: "*" } })
-const PORT = process.env.PORT || 3001 
+const PORT = process.env.PORT || 3001
 
 const { Player } = require('./src/Player')
 
@@ -18,7 +18,7 @@ io.on('connection', socket => {
   socket.emit('update games', games)
 
   /**
-   * If disconnected user hosted any games those games are terminated TODO: overkill?
+   * If disconnected user hosted any games those games are terminated
    * Then user is removed from connectedUsers
    */
   socket.on('disconnect', () => {
@@ -173,6 +173,7 @@ io.on('connection', socket => {
     for (let socketID of games[gameID].connections) {
       io.to(socketID).emit('game update', games[gameID])
     }
+    io.emit('update games', games)
   })
 })
 


### PR DESCRIPTION
1) Joining to a game where first move had already been made sometimes caused chessboardjsx to fail to load board state.

2) Moves that happened in non-selected games didn't update games in game list causing players to see old board states when switching to other games.